### PR TITLE
Fix for everything being purged

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,7 @@
 module.exports = {
-  purge: {
-    enabled: false,
-    content: ['./src/**/*.html'],
-  },
+  purge: [
+    './_site/**/*.html'
+  ],
   theme: {
     screens: {
       'sm': '640px',


### PR DESCRIPTION
Slight hack (pointing purging to the built HTML instead of the src, because the src is scattered all over the root). Works because gulp pipeline generates _site HTML first and then turns to Tailwind processing.